### PR TITLE
feat: 상품별 결제내역 저장 구현

### DIFF
--- a/src/main/java/egenius/orders/domain/batch/jobs/PaymentTransferJob.java
+++ b/src/main/java/egenius/orders/domain/batch/jobs/PaymentTransferJob.java
@@ -73,7 +73,8 @@ public class PaymentTransferJob {
 
 
     // 3. reader -> QueryDsl은 Tuple형태로 데이터를 return하므로 제네릭에 tuple을 적는다
-    // todo: noOffset으로 성능향상 시켜보
+    // 넘길 자료를 취합 : 결제 1건당 -> 결제금액, 결제수단, 상품명, 상품코드, 승인날짜, 판매자email 필요함
+    // todo: noOffset으로 성능향상 시켜보기
     // todo: order 도메인이 완성되면, paymentKey에 해당하는 order를 조회하고 vendorEmail를 넣기
     @Bean
     public QuerydslPagingItemReader<Tuple> reader() {

--- a/src/main/java/egenius/orders/domain/payment/dto/PaymentRequestDto.java
+++ b/src/main/java/egenius/orders/domain/payment/dto/PaymentRequestDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 // modelMapper에서 mapping을 할때 기본 생성자(NoArgs)가 꼭 필요하다
 // java에서는 생성자를 만들어주지 않으면 자동으로 기본 생성자를 생성해준다 -> 아무런 어노테이션을 붙여주지 않아도 됨!
@@ -29,4 +30,7 @@ public class PaymentRequestDto {
     private String receipt_url;
 
     private Integer balanceAmount;
+
+    private List<ProductPaymentDto> productPaymentList;
+
 }

--- a/src/main/java/egenius/orders/domain/payment/dto/ProductPaymentDto.java
+++ b/src/main/java/egenius/orders/domain/payment/dto/ProductPaymentDto.java
@@ -1,0 +1,24 @@
+package egenius.orders.domain.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ProductPaymentDto {
+    private String vendorEmail;
+
+    private String productName;
+
+    private String productCode;
+
+    private String productMainImageUrl;
+
+    private Integer productAmount;
+
+    private Integer count;
+}

--- a/src/main/java/egenius/orders/domain/payment/entity/Payment.java
+++ b/src/main/java/egenius/orders/domain/payment/entity/Payment.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Entity
@@ -46,11 +47,16 @@ public class Payment {
     @Column(name = "balance_amount", nullable = false)
     private Integer balanceAmount;
 
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_payment_id", referencedColumnName = "id")
+    private List<ProductPayment> productPaymentList;
+
 
     /**
      * Payment
      * 1. 결제상태 업데이트
      * 2. 취소가능 잔고 업데이트
+     * 3. 상품 결제내역 업데이트
      */
 
     // 1. 결제상태 업데이트
@@ -66,4 +72,10 @@ public class Payment {
             throw new BaseException(BaseResponseStatus.CANCELED_AMOUNT_EXCEEDED);
         }
     }
+
+    // 3. 상품 결제내역 업데이트
+    public void updateProductPayment(List productPaymentList) {
+        this.productPaymentList = productPaymentList;
+    }
+
 }

--- a/src/main/java/egenius/orders/domain/payment/entity/ProductPayment.java
+++ b/src/main/java/egenius/orders/domain/payment/entity/ProductPayment.java
@@ -1,0 +1,35 @@
+package egenius.orders.domain.payment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "product_payment")
+public class ProductPayment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "vendor_email")
+    private String vendorEmail;
+
+    @Column(name = "product_name")
+    private String productName;
+
+    @Column(name = "product_code")
+    private String productCode;
+
+    @Column(name = "product_main_image_url")
+    private String productMainImageUrl;
+
+    @Column(name = "product_amount")
+    private Integer productAmount;
+
+    @Column(name = "count")
+    private Integer count;
+}

--- a/src/main/java/egenius/orders/domain/payment/infrastructure/ProductPaymentRepository.java
+++ b/src/main/java/egenius/orders/domain/payment/infrastructure/ProductPaymentRepository.java
@@ -1,0 +1,9 @@
+package egenius.orders.domain.payment.infrastructure;
+
+import egenius.orders.domain.payment.entity.ProductPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductPaymentRepository extends JpaRepository<ProductPayment, Long> {
+}

--- a/src/main/java/egenius/orders/domain/payment/presentation/PaymentController.java
+++ b/src/main/java/egenius/orders/domain/payment/presentation/PaymentController.java
@@ -25,10 +25,11 @@ public class PaymentController {
      * payment
      * 1. 결제
      * 2. 결제 취소
+     * 3. 상품별 결제
      */
 
     //1. 결제
-    @Operation(summary = "결제", description = "결제내역 저장", tags = { "Orders Payment" })
+    @Operation(summary = "결제", description = "결제내역 저장", tags = {"Orders Payment"})
     @PostMapping("")
     public BaseResponse<?> requestPayment(@RequestBody PaymentInWebDto inDto) {
         PaymentRequestDto requestDto = modelMapper.map(inDto, PaymentRequestDto.class);
@@ -37,7 +38,7 @@ public class PaymentController {
     }
 
     //2. 결제 취소
-    @Operation(summary = "결제 취소", description = "결제 취소", tags = { "Orders Payment" })
+    @Operation(summary = "결제 취소", description = "결제 취소", tags = {"Orders Payment"})
     @PostMapping("/cancel")
     public BaseResponse<?> cancelPayment(@RequestBody CancelsInWebDto inDto) {
         CancelsRequestDto requestDto = modelMapper.map(inDto, CancelsRequestDto.class);

--- a/src/main/java/egenius/orders/domain/payment/webdto/PaymentInWebDto.java
+++ b/src/main/java/egenius/orders/domain/payment/webdto/PaymentInWebDto.java
@@ -1,11 +1,13 @@
 package egenius.orders.domain.payment.webdto;
 
+import egenius.orders.domain.payment.dto.ProductPaymentDto;
 import egenius.orders.domain.payment.entity.PaymentMethod;
 import egenius.orders.domain.payment.entity.PaymentStatus;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @ToString
@@ -29,4 +31,6 @@ public class PaymentInWebDto {
     private LocalDateTime requestedAt;
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime approvedAt;
+
+    private List<ProductPaymentDto> productPaymentList;
 }


### PR DESCRIPTION
# 구현 및 변경점 👍
- payment : paymentDto를 List로 가지도록 변경
- productPayment : 상품별 결재 내역

# 스크린샷 🖼
- productPayment를 리스트로 보내기
  <img width="472" alt="image" src="https://github.com/Spharos-GentleDog/BE-orders/assets/108791919/bc3864dc-5cb1-46cb-a6dc-20b77810dc59">
- 저장 완료
  ![image](https://github.com/Spharos-GentleDog/BE-orders/assets/108791919/03da0eaa-87ad-48d8-aed1-8be052b4bbd2)

 
# 비고 ✏
- Payment와 ProductPayment는 OneToMany관계, Payment에서는 ProductPayment 정보가 필요해서 1:N 관계지만 1쪽에 key를 List로 들고있음
- WebDto에서 List로 받는 형태로 구현