### PR TITLE
fix: compact 사용시 key가 꼭 필요하기에 삭제

### DIFF
--- a/src/main/java/egenius/orders/global/config/kafka/KafkaAdminConfig.java
+++ b/src/main/java/egenius/orders/global/config/kafka/KafkaAdminConfig.java
@@ -41,7 +41,6 @@ public class KafkaAdminConfig {
                 .partitions(5)
                 .replicas(1)
                 .configs(configs)
-                .compact()
                 .build();
     }
 


### PR DESCRIPTION
# 버그 해결 💊
- topic : Topic Builder 에서 compact 삭제 
