### PR TITLE
fix: 상품 결제내역이 두 번 저장되던 버그 해결

### DIFF
--- a/src/main/java/egenius/orders/domain/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/egenius/orders/domain/payment/application/PaymentServiceImpl.java
@@ -48,15 +48,11 @@ public class PaymentServiceImpl implements PaymentService{
 
         // modelMapper를 사용하여 entity 생성
         Payment payment = modelMapper.map(requestDto, Payment.class);
+        // 각 상품에 Payment를 추가
+        payment.getProductPaymentList().forEach(
+                product -> product.updatePayment(payment));
+        // payment와 productPayment를 같이 저장한다
         paymentRepository.save(payment);
-
-        // 상품 결제내역 저장
-        List<ProductPaymentDto> productList = requestDto.getProductPaymentList();
-        productList.forEach(product -> {
-            ProductPayment productPayment = modelMapper.map(product, ProductPayment.class);
-            productPayment.updatePayment(payment);
-            productPaymentRepository.save(productPayment);
-            });
     }
 
     // 2. 결제 키로 조회

--- a/src/main/java/egenius/orders/domain/payment/dto/ProductPaymentDto.java
+++ b/src/main/java/egenius/orders/domain/payment/dto/ProductPaymentDto.java
@@ -1,5 +1,6 @@
 package egenius.orders.domain.payment.dto;
 
+import egenius.orders.domain.payment.entity.Payment;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,4 +22,10 @@ public class ProductPaymentDto {
     private Integer productAmount;
 
     private Integer count;
+
+    private Payment payment;
+
+    public void updatePayment(Payment payment) {
+        this.payment = payment;
+    }
 }


### PR DESCRIPTION

 
# 버그 해결 💊
- PaymentServiceImpl : request에서 productPayment가 payment안에 포함되어서 들어오는데, 그대로 payment를 저장시키면 productPayment도 동시에 저장됨. 따라서 중복되는 부분을 제거하였음 
 
# 스크린샷 🖼
- null이 포함된 부분과, 값이 존재하는 부분으로 총 2번씩 저장되던게, 28번부터는 해결되었음
![image](https://github.com/Spharos-GentleDog/BE-orders/assets/108791919/30ec3218-20c4-41d3-8a2a-1fcbcdab23ad)
