### PR TITLE
hotfix: null값인 groupId를 주면 해당 유저의 제일 높은 groupId를 반환

### DIFF
--- a/src/main/java/egenius/orders/domain/orders/application/users/UsersOrderServiceImple.java
+++ b/src/main/java/egenius/orders/domain/orders/application/users/UsersOrderServiceImple.java
@@ -150,6 +150,10 @@ public class UsersOrderServiceImple implements UsersOrderService {
         VendorsOrderList vendorsOrderList = vendorsOrderListRepository.
                 findByNextGroupId(userEmail, lastElement);
 
+        if (vendorsOrderList != null) {
+            vendorsOrderList = vendorsOrderListRepository.findMaxGroupId(userEmail);
+        }
+
         // vendorsOrderList가 null이라면 nextGroupId는 null로 전달
         Long nextGroupId = vendorsOrderList == null ? null : vendorsOrderList.getGroupId();
 


### PR DESCRIPTION
# 버그 해결 💊
hotfix: null값인 groupId를 주면 해당 유저의 제일 높은 groupId를 반환

![image](https://github.com/Spharos-GentleDog/BE-orders/assets/94760980/d47408fe-2d53-458a-8022-eecbf11551d8)


